### PR TITLE
ci: Add node_modules/.bin to PATH for Hugo TailwindCSS build

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -27,6 +27,9 @@ jobs:
       - name: Install npm dependencies (frozen)
         run: npm ci
 
+      - name: Add node_modules/.bin to PATH
+        run: echo "$(pwd)/node_modules/.bin" >> "$GITHUB_PATH"
+
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:


### PR DESCRIPTION

Hugo's `css.TailwindCSS` function requires the `tailwindcss` CLI binary on `PATH`. `npm ci` installs it into `node_modules/.bin/`, but that directory isn't on `PATH` by default in GitHub Actions runners.

This adds a step to append `node_modules/.bin` to `GITHUB_PATH` after `npm ci`, ensuring Hugo can find the `tailwindcss` binary during site builds.

Fixes the CI build failure:
```
TAILWINDCSS: failed to transform "/css/main.css" (text/css). You need to install TailwindCSS CLI. binary with name "tailwindcss" not found in PATH
```
