### PR TITLE
fix(config): replace deprecated languageCode with locale

### DIFF
--- a/exampleSite/content/configuration/site-settings.md
+++ b/exampleSite/content/configuration/site-settings.md
@@ -42,7 +42,7 @@ For local development, you can omit this or set it to `http://localhost:1313/`.
 
 ### Language
 
-Set the default language code:
+Set the default locale:
 
 ```yaml
 locale: 'en-us'

--- a/exampleSite/content/configuration/site-settings.md
+++ b/exampleSite/content/configuration/site-settings.md
@@ -45,7 +45,7 @@ For local development, you can omit this or set it to `http://localhost:1313/`.
 Set the default language code:
 
 ```yaml
-languageCode: 'en-us'
+locale: 'en-us'
 ```
 
 ## Favicons
@@ -117,7 +117,7 @@ params:
 
 ```yaml
 baseURL: 'https://myblog.com'
-languageCode: 'en-us'
+locale: 'en-us'
 title: 'My Blog'
 theme: 'fortyten'
 
@@ -184,7 +184,7 @@ Here's a minimal `hugo.yaml` for a FortyTen site:
 
 ```yaml
 baseURL: 'https://myblog.com'
-languageCode: 'en-us'
+locale: 'en-us'
 title: 'My Blog'
 theme: 'fortyten'
 

--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -1,5 +1,5 @@
 baseURL: 'https://fortyten.marcelorodrigo.com'
-languageCode: 'en-us'
+locale: 'en-us'
 title: 'FortyTen Theme'
 theme: 'fortyten'
 menus:


### PR DESCRIPTION
Renames `languageCode` to `locale` in `exampleSite/hugo.yaml` to resolve Hugo v0.158.0 deprecation warning.