### PR TITLE
feat!: support Hugo v0.161.0+ Tailwind CSS npm requirement

### DIFF
--- a/exampleSite/content/configuration/site-settings.md
+++ b/exampleSite/content/configuration/site-settings.md
@@ -163,20 +163,53 @@ This includes:
 - Server configuration
 - And much more
 
-## Tailwind CSS Stats
+## Tailwind CSS Build Configuration
 
-FortyTen uses Tailwind CSS v4 with automatic class detection via Hugo's build stats. If you want your extra tailwindcss classes to be added, you must enable stats writing in your configuration:
+FortyTen uses Tailwind CSS v4 with Hugo's `css.TailwindCSS` function. As of Hugo v0.161.0, the Tailwind CLI must be installed via npm (standalone binary no longer supported).
+
+### Required Hugo Config
+
+Add the following to your `hugo.yaml` to enable build stats and mount them so Tailwind can detect your utility class usage:
 
 ```yaml
 build:
-  writeStats: true
+  buildStats:
+    enable: true
+  cachebusters:
+  - source: 'assets/notwatching/hugo_stats\.json'
+    target: css
+  - source: '(postcss|tailwind)\.config\.js'
+    target: css
+module:
+  mounts:
+  - source: assets
+    target: assets
+  - disableWatch: true
+    source: hugo_stats.json
+    target: assets/notwatching/hugo_stats.json
 ```
 
-This generates a `hugo_stats.json` file at your project root, which the theme's CSS uses to detect and include only the Tailwind classes actually used in your content.
+This configuration:
 
-**Required for:**
-- Theme consumers using `@source "hugo_stats.json"` in their CSS
-- Automatic purging/optimization of Tailwind utility classes
+- **`buildStats.enable: true`** — generates a `hugo_stats.json` file tracking which Tailwind classes are used across your templates
+- **`cachebusters`** — forces CSS rebuilds when the stats file or Tailwind config changes
+- **`module.mounts`** — makes `hugo_stats.json` available to Tailwind's `@source` directive in your CSS (the `assets/notwatching/` prefix prevents Hugo from registering the file itself as a build asset)
+
+### Required npm Packages
+
+Install the Tailwind CLI via npm (the standalone binary is no longer supported):
+
+```bash
+npm install --save-dev tailwindcss @tailwindcss/cli @tailwindcss/typography
+```
+
+### Build Command
+
+When deploying, the `tailwindcss` binary must be in PATH. Use `$(npm root)/.bin` to resolve the absolute path (Hugo may change the working directory during the build, so relative paths break):
+
+```bash
+npm install && PATH="$(npm root)/.bin:$PATH" hugo --minify
+```
 
 ## Complete Example
 
@@ -207,4 +240,20 @@ menus:
       name: 'Posts'
       url: '/posts'
       weight: 2
+
+build:
+  buildStats:
+    enable: true
+  cachebusters:
+  - source: 'assets/notwatching/hugo_stats\.json'
+    target: css
+  - source: '(postcss|tailwind)\.config\.js'
+    target: css
+module:
+  mounts:
+  - source: assets
+    target: assets
+  - disableWatch: true
+    source: hugo_stats.json
+    target: assets/notwatching/hugo_stats.json
 ```

--- a/exampleSite/content/setup.md
+++ b/exampleSite/content/setup.md
@@ -11,7 +11,7 @@ image: "https://images.unsplash.com/photo-1461896836934-ffe607ba8211?q=80"
 
 ### Install Hugo Extended
 
-FortyTen requires **Hugo Extended** (v0.140.2+) for Tailwind CSS support.
+FortyTen requires **Hugo Extended** (v0.161.0+) for Tailwind CSS support. As of v0.161.0, Hugo no longer supports the standalone Tailwind binary — the Tailwind CSS CLI must be installed via npm.
 Download it from [hugo.io](https://gohugo.io/installation/).
 
 **macOS (Homebrew):**
@@ -36,21 +36,13 @@ hugo version
 
 ### Install Tailwind CSS CLI
 
-**About Tailwind CLI:**
-The simplest and fastest way to get up and running with Tailwind CSS from scratch is with the Tailwind CLI tool. The CLI is also available as a standalone executable if you want to use it without installing Node.js.
+FortyTen requires Tailwind CSS v4 with the Tailwind CLI installed locally via npm. As of Hugo v0.161.0, the standalone Tailwind binary is no longer supported — you must install the npm package.
 
-**Using npx (no installation required):**
 ```bash
-npx @tailwindcss/cli --help
+npm install --save-dev tailwindcss @tailwindcss/cli @tailwindcss/typography
 ```
 
-**For faster builds (install locally):**
-```bash
-npm install -D tailwindcss @tailwindcss/cli @tailwindcss/typography
-npx tailwindcss --help
-```
-
-> **Note:** Hugo's `css.TailwindCSS` function requires the Tailwind CLI binary. Using `npx` downloads it on first run.
+> **Note:** Hugo's `css.TailwindCSS` function calls the `tailwindcss` binary directly. A local npm install places it in `node_modules/.bin/tailwindcss`, which Hugo resolves automatically when it's in PATH.
 
 ### Create a New Site
 
@@ -91,6 +83,11 @@ hugo --minify
 ```
 
 Output will be in the `public/` directory.
+
+> **Important:** Some deployment environments (e.g., Cloudflare Pages) may not have `node_modules/.bin` in PATH. If you get a "binary not found" error, add it explicitly:
+> ```bash
+> npm install && PATH="$(npm root)/.bin:$PATH" hugo --minify
+> ```
 
 ### Deployment
 
@@ -138,6 +135,19 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public
 ```
+
+#### Deploy to Cloudflare Pages
+
+Set the following in the Cloudflare Pages dashboard:
+
+- **Build command:**
+  ```bash
+  npm install && PATH="$(npm root)/.bin:$PATH" hugo --minify
+  ```
+- **Build output directory:** `public`
+- **Root directory (optional):** `exampleSite` (if deploying the demo site)
+
+Cloudflare Pages includes Hugo Extended by default. No additional configuration is needed.
 
 ---
 

--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -76,4 +76,17 @@ params:
   enableSiteSearch: true
 
 build:
-  writeStats: true
+  buildStats:
+    enable: true
+  cachebusters:
+  - source: 'assets/notwatching/hugo_stats\.json'
+    target: css
+  - source: '(postcss|tailwind)\.config\.js'
+    target: css
+module:
+  mounts:
+  - source: assets
+    target: assets
+  - disableWatch: true
+    source: hugo_stats.json
+    target: assets/notwatching/hugo_stats.json


### PR DESCRIPTION
As of Hugo v0.161.0, the standalone Tailwind CSS binary is no longer supported. The Tailwind CLI must now be installed via npm, and the build environment must have it in PATH.

This PR updates the theme configuration and documentation to work with Hugo v0.161.0+.

## Changes

- **exampleSite/hugo.yaml**: Replace `build.writeStats` with the full `buildStats` + `cachebusters` + `module.mounts` config required by `css.TailwindCSS`
- **setup.md**: Remove standalone binary references, add PATH fix note, add Cloudflare Pages deploy section
- **site-settings.md**: Document full build config, npm packages, and corrected build command
- Bump minimum Hugo version from **v0.140.2** to **v0.161.0**

## Build Command Fix

For deployment environments where `node_modules/.bin` is not in PATH (e.g., Cloudflare Pages):

```bash
npm install && PATH="$(npm root)/.bin:$PATH" hugo --minify
```

Uses `$(npm root)/.bin` to resolve the absolute path, which is more robust than relative paths that break when Hugo changes its working directory during the build.

Fixes Cloudflare Pages build failure: `binary with name "tailwindcss" not found in PATH`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Tailwind CSS and Hugo build configuration guide with new setup requirements.
  * Hugo Extended v0.161.0+ now required; Tailwind CSS CLI must be installed via npm.
  * Added Cloudflare Pages deployment instructions with environment-specific build commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->