### PR TITLE
feat(theme): Add GitHub nav link and bump Hugo to v0.161.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ Purpose: concise instructions and discoverable patterns for AI coding agents wor
 ## What this project is
 - **Hugo theme repository**: contains both the theme (`layouts/`, `assets/`) and a demo site (`exampleSite/`).
 - Tailwind CSS v4 with typography plugin, Alpine.js for interactivity, Ionicons for icons.
-- Requires Hugo Extended (min v0.140.2) — Hugo handles Tailwind builds via `css.TailwindCSS`.
+- Requires Hugo Extended (min v0.161.0) — Hugo handles Tailwind builds via `css.TailwindCSS`.
 
 ## Repository structure
 ```

--- a/README.md
+++ b/README.md
@@ -51,22 +51,20 @@ hugo --minify
 
 ## Requirements
 
-- **Hugo Extended** (v0.140.2+)
-- **Node.js** (v20+)
-- **Tailwind CSS v4 CLI** - Processed by Hugo via `npx tailwindcss` or locally installed
+- **Hugo Extended** (v0.161.0+) — required for `css.TailwindCSS` processing
+- **Node.js** (v20+) — required for Tailwind CSS and npm dependencies
 
-**About Tailwind CLI:**
-The simplest and fastest way to get up and running with Tailwind CSS from scratch is with the Tailwind CLI tool. The CLI is also available as a standalone executable if you want to use it without installing Node.js.
+As of v0.161.0, Hugo no longer supports the Tailwind standalone binary. You must install the Tailwind CSS CLI via npm.
 
 Verify:
 ```shell
-hugo version              # Should show "extended"
-npx tailwindcss --help    # Verify Tailwind CLI is installed
+hugo version    # Should show "extended"
+node --version  # Should be v20+
 ```
 
-**Optional:** Install Tailwind CLI locally for faster builds:
+Install dependencies:
 ```shell
-npm install tailwindcss @tailwindcss/cli @tailwindcss/typography
+npm install --save-dev tailwindcss @tailwindcss/cli @tailwindcss/typography
 ```
 
 ## Configuration

--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -60,6 +60,12 @@ menus:
     url: '/shortcodes/gist'
     parent: 'shortcodes'
     weight: 5
+  - identifier: 'github'
+    name: 'GitHub'
+    url: 'https://github.com/marcelo/hugo-fortyten'
+    weight: 100
+    params:
+      icon: 'logo-github'
 outputs:
   home:
     - HTML

--- a/exampleSite/hugo.yaml
+++ b/exampleSite/hugo.yaml
@@ -62,7 +62,7 @@ menus:
     weight: 5
   - identifier: 'github'
     name: 'GitHub'
-    url: 'https://github.com/marcelo/hugo-fortyten'
+    url: 'https://github.com/marcelorodrigo/hugo-fortyten'
     weight: 100
     params:
       icon: 'logo-github'

--- a/theme.toml
+++ b/theme.toml
@@ -39,5 +39,5 @@ name = 'Marcelo Wiebbelling'
 homepage = 'https://marcelorodrigo.com'
 
 [module.hugoVersion]
-min = '0.140.2'
+min = '0.161.0'
 extended = true


### PR DESCRIPTION
Add a GitHub icon link to the top navigation menu in the demo site, pointing to the repository.

Bump Hugo minimum version from v0.140.2 to v0.161.0 across README.md, theme.toml, and AGENTS.md. Hugo v0.161.0 dropped support for the Tailwind standalone binary — the README now documents the required npm install step for Tailwind CSS dependencies.

## Changes

- Add GitHub link with  icon to demo site nav menu
- Bump Hugo min version to v0.161.0 in  (authoritative source)
- Update README Requirements section: correct Hugo version, explain Tailwind npm requirement, add install command
- Update AGENTS.md to reflect new Hugo minimum

No template changes were needed for the nav icon — the existing  partial already supports icons via .