### PR TITLE
fix: Replace deprecated Hugo v0.158.0 language properties

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ site.Language.LanguageCode }}" dir="{{ or site.Language.LanguageDirection `ltr` }}">
+<html lang="{{ site.Language.Locale }}" dir="{{ or site.Language.Direction `ltr` }}">
 <head>
   {{ partial "head.html" . }}
 </head>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ site.Language.Locale }}" dir="{{ or site.Language.Direction `ltr` }}">
+<html lang="{{ site.Language.LanguageCode }}" dir="{{ or site.Language.LanguageDirection `ltr` }}">
 <head>
   {{ partial "head.html" . }}
 </head>


### PR DESCRIPTION

## What

Replace deprecated Hugo language template properties to eliminate build warnings:

- `site.Language.LanguageCode` → `site.Language.Locale`
- `site.Language.LanguageDirection` → `site.Language.Direction`

## Why

Hugo v0.158.0 (March 2026) deprecated these properties to eliminate API stutter. The old properties still work but produce warnings. The new properties require Hugo v0.158.0+.

## Cloudflare Pages Setup

The Cloudflare Pages build environment uses an older Hugo version by default. To fix the build:

1. Go to **Cloudflare Pages** → your project → **Settings** → **Environment variables**
2. Add: `HUGO_VERSION` = `0.162.1`
3. Redeploy

Alternatively, the GitHub Actions CI already uses `hugo-version: 'latest'` and will work without changes.
